### PR TITLE
Do not remove node_modules from container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -27,8 +27,7 @@ USER 1001
 WORKDIR $HOME
 RUN echo "Using npm location: $NPMLOCATION" && \
     npm install && \
-    npm run build && \
-    rm -rf node_modules
+    npm run build
 
 # Provide defaults for an executing container
 # Later, helm-chart will set 'NPM_RUN' variable to 'start:server'


### PR DESCRIPTION
Since the application is running on the backed, Node relies on the `node_modules` directory to be present and populated. It is OK to remove the directory for front-end applications (e.g. ciboard) where the code is bundled and served in a couple of static files, but we must keep the directory here.