### PR TITLE
Update Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,6 +20,8 @@ COPY src/ $HOME/src/
 COPY package.json package-lock.json env.sh tsconfig.json $HOME/
 COPY .npmrcs/$NPMLOCATION .npmrc
 RUN chmod a+w "$HOME/package-lock.json"
+# cache folder contains root-owned files, due to a bug in npm, previous versions of npm which has since been addressed.
+RUN chown -R 1001:0 "$HOME/.npm"
 
 # USER doesn't impact on COPY
 USER 1001


### PR DESCRIPTION
```
> ciboard-server@1.0.0 start:server
> source ./env.sh && node build/server.js | ./node_modules/.bin/pino-pretty

npm ERR! code EACCES
npm ERR! syscall open
npm ERR! path /opt/app-root/src/.npm/_cacache/tmp/c41d0dc8
npm ERR! errno -13
npm ERR! 
npm ERR! Your cache folder contains root-owned files, due to a bug in
npm ERR! previous versions of npm which has since been addressed.
npm ERR! 
npm ERR! To permanently fix this problem, please run:
npm ERR!   sudo chown -R 1004080000:0 "/opt/app-root/src/.npm"
npm timing npm Completed in 570ms

npm ERR! Log files were not written due to an error writing to the directory: /opt/app-root/src/.npm/_logs
npm ERR! You can rerun the command with `--loglevel=verbose` to see the logs in your terminal
```