### PR TITLE
Fix chmod call in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,8 +20,6 @@ COPY src/ $HOME/src/
 COPY package.json package-lock.json env.sh tsconfig.json $HOME/
 COPY .npmrcs/$NPMLOCATION .npmrc
 RUN chmod a+w "$HOME/package-lock.json"
-# cache folder contains root-owned files, due to a bug in npm, previous versions of npm which has since been addressed.
-RUN chown -R 1001:0 "$HOME/.npm"
 
 # USER doesn't impact on COPY
 USER 1001
@@ -29,7 +27,10 @@ USER 1001
 WORKDIR $HOME
 RUN echo "Using npm location: $NPMLOCATION" && \
     npm install && \
-    npm run build
+    npm run build && \
+    # cache folder contains root-owned files, due to a bug in npm, \
+    # previous versions of npm which has since been addressed. \
+    chown -R 1001:0 "$HOME/.npm"
 
 # Provide defaults for an executing container
 # Later, helm-chart will set 'NPM_RUN' variable to 'start:server'


### PR DESCRIPTION
The `chmod` command needs to be run after `npm install` as the `~/.npm` directory is not guaranteed to exist before that.

Follow-up to fc7649b.