### PR TITLE
Revert "Introduce metadata inheritance"

### DIFF
--- a/src/schema/root_query_type.ts
+++ b/src/schema/root_query_type.ts
@@ -847,18 +847,10 @@ const RootQuery = new GraphQLObjectType({
               },
             };
             const query: Filter<MetadataModel> = { $expr: testcaseName };
-            /*
-             * If `product_version` is specified, query for empty product as well and
-             * merge the results (with the product-specific values taking precedence).
-             */
             if (_.has(args, 'product_version')) {
-              query.product_version = { $in: [null, product_version] };
+              query.product_version = product_version;
             }
-            const docs = await col.find([
-              { $match: query },
-              // Make sure empty product comes first.
-              { $sort: { product_version: 1 } },
-            ]);
+            const docs = await col.find(query);
             const mergedMetadata = _.mergeWith(
               {},
               ..._.map(docs, 'payload'),


### PR DESCRIPTION
This reverts commit 10f6219f938ba0363c66cfb528bdb82fa1e030e4.

I'll have to roll back this change. The code needs to be be adjusted in the db layer to allow for aggregations first.