### PR TITLE
Add Sentry integration

### DIFF
--- a/env.sh
+++ b/env.sh
@@ -1,6 +1,8 @@
 #!/bin/bash
 # production
 # export NODE_ENV="${NODE_ENV:-development}"
+# export SENTRY_DSN="${SENTRY_DSN}"
+# export SENTRY_ENVIRONMENT="${SENTRY_ENVIRONMENT:-development}"
 # export SRV_PORT="${SRV_PORT:-}"
 # export SRV_COOKIE_KEY="${SRV_COOKIE_KEY:-}" ~
 # export SRV_AUTH_ENABLED="${SRV_AUTH_ENABLED:-}"

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "license": "LGPL-3.0-or-later",
       "dependencies": {
         "@graphql-tools/delegate": "^9.0.35",
+        "@sentry/node": "^7.51.2",
         "ajv": "^8.12.0",
         "ajv-formats": "^2.1.1",
         "axios": "^1.4.0",
@@ -2337,6 +2338,100 @@
       "resolved": "https://registry.npmjs.org/@repeaterjs/repeater/-/repeater-3.0.4.tgz",
       "integrity": "sha512-AW8PKd6iX3vAZ0vA43nOUOnbq/X5ihgU+mSXXqunMkeQADGiqw/PY0JNeYtD5sr0PAy51YPgAPbDoeapv9r8WA=="
     },
+    "node_modules/@sentry-internal/tracing": {
+      "version": "7.51.2",
+      "resolved": "https://repository.engineering.redhat.com/nexus/repository/registry.npmjs.org/@sentry-internal/tracing/-/tracing-7.51.2.tgz",
+      "integrity": "sha512-OBNZn7C4CyocmlSMUPfkY9ORgab346vTHu5kX35PgW5XR51VD2nO5iJCFbyFcsmmRWyCJcZzwMNARouc2V4V8A==",
+      "license": "MIT",
+      "dependencies": {
+        "@sentry/core": "7.51.2",
+        "@sentry/types": "7.51.2",
+        "@sentry/utils": "7.51.2",
+        "tslib": "^1.9.3"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@sentry-internal/tracing/node_modules/tslib": {
+      "version": "1.14.1",
+      "resolved": "https://repository.engineering.redhat.com/nexus/repository/registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
+      "license": "0BSD"
+    },
+    "node_modules/@sentry/core": {
+      "version": "7.51.2",
+      "resolved": "https://repository.engineering.redhat.com/nexus/repository/registry.npmjs.org/@sentry/core/-/core-7.51.2.tgz",
+      "integrity": "sha512-p8ZiSBxpKe+rkXDMEcgmdoyIHM/1bhpINLZUFPiFH8vzomEr7sgnwRhyrU8y/ADnkPeNg/2YF3QpDpk0OgZJUA==",
+      "license": "MIT",
+      "dependencies": {
+        "@sentry/types": "7.51.2",
+        "@sentry/utils": "7.51.2",
+        "tslib": "^1.9.3"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@sentry/core/node_modules/tslib": {
+      "version": "1.14.1",
+      "resolved": "https://repository.engineering.redhat.com/nexus/repository/registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
+      "license": "0BSD"
+    },
+    "node_modules/@sentry/node": {
+      "version": "7.51.2",
+      "resolved": "https://repository.engineering.redhat.com/nexus/repository/registry.npmjs.org/@sentry/node/-/node-7.51.2.tgz",
+      "integrity": "sha512-qtZ2xNVR0ZW+OZWb0Xw0Cdh2QJXOJkXjK84CGC2P4Y6jWrt+GVvwMANPItLT6mAh+ITszTJ5Gk5HHFRpYme5EA==",
+      "license": "MIT",
+      "dependencies": {
+        "@sentry-internal/tracing": "7.51.2",
+        "@sentry/core": "7.51.2",
+        "@sentry/types": "7.51.2",
+        "@sentry/utils": "7.51.2",
+        "cookie": "^0.4.1",
+        "https-proxy-agent": "^5.0.0",
+        "lru_map": "^0.3.3",
+        "tslib": "^1.9.3"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@sentry/node/node_modules/tslib": {
+      "version": "1.14.1",
+      "resolved": "https://repository.engineering.redhat.com/nexus/repository/registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
+      "license": "0BSD"
+    },
+    "node_modules/@sentry/types": {
+      "version": "7.51.2",
+      "resolved": "https://repository.engineering.redhat.com/nexus/repository/registry.npmjs.org/@sentry/types/-/types-7.51.2.tgz",
+      "integrity": "sha512-/hLnZVrcK7G5BQoD/60u9Qak8c9AvwV8za8TtYPJDUeW59GrqnqOkFji7RVhI7oH1OX4iBxV+9pAKzfYE6A6SA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@sentry/utils": {
+      "version": "7.51.2",
+      "resolved": "https://repository.engineering.redhat.com/nexus/repository/registry.npmjs.org/@sentry/utils/-/utils-7.51.2.tgz",
+      "integrity": "sha512-EcjBU7qG4IG+DpIPvdgIBcdIofROMawKoRUNKraeKzH/waEYH9DzCaqp/mzc5/rPBhpDB4BShX9xDDSeH+8c0A==",
+      "license": "MIT",
+      "dependencies": {
+        "@sentry/types": "7.51.2",
+        "tslib": "^1.9.3"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@sentry/utils/node_modules/tslib": {
+      "version": "1.14.1",
+      "resolved": "https://repository.engineering.redhat.com/nexus/repository/registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
+      "license": "0BSD"
+    },
     "node_modules/@sinclair/typebox": {
       "version": "0.24.51",
       "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.24.51.tgz",
@@ -2780,6 +2875,18 @@
       "dev": true,
       "engines": {
         "node": ">=0.4.0"
+      }
+    },
+    "node_modules/agent-base": {
+      "version": "6.0.2",
+      "resolved": "https://repository.engineering.redhat.com/nexus/repository/registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
+      "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6.0.0"
       }
     },
     "node_modules/ajv": {
@@ -4520,6 +4627,19 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/https-proxy-agent": {
+      "version": "5.0.1",
+      "resolved": "https://repository.engineering.redhat.com/nexus/repository/registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
+      "integrity": "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==",
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "6",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
     "node_modules/human-signals": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-2.1.0.tgz",
@@ -5551,6 +5671,12 @@
       "resolved": "https://registry.npmjs.org/lodash.memoize/-/lodash.memoize-4.1.2.tgz",
       "integrity": "sha512-t7j+NzmgnQzTAYXcsHYLgimltOV1MXHtlOWf6GjL9Kj8GK5FInw5JotxvbOs+IvV1/Dzo04/fCGfLVs7aXb4Ag==",
       "dev": true
+    },
+    "node_modules/lru_map": {
+      "version": "0.3.3",
+      "resolved": "https://repository.engineering.redhat.com/nexus/repository/registry.npmjs.org/lru_map/-/lru_map-0.3.3.tgz",
+      "integrity": "sha512-Pn9cox5CsMYngeDbmChANltQl+5pi6XmTrraMSzhPmMBbmgcxmqWry0U3PGapCU1yB4/LqCcom7qhHZiF/jGfQ==",
+      "license": "MIT"
     },
     "node_modules/lru-cache": {
       "version": "5.1.1",
@@ -9935,6 +10061,84 @@
       "resolved": "https://registry.npmjs.org/@repeaterjs/repeater/-/repeater-3.0.4.tgz",
       "integrity": "sha512-AW8PKd6iX3vAZ0vA43nOUOnbq/X5ihgU+mSXXqunMkeQADGiqw/PY0JNeYtD5sr0PAy51YPgAPbDoeapv9r8WA=="
     },
+    "@sentry-internal/tracing": {
+      "version": "7.51.2",
+      "resolved": "https://repository.engineering.redhat.com/nexus/repository/registry.npmjs.org/@sentry-internal/tracing/-/tracing-7.51.2.tgz",
+      "integrity": "sha512-OBNZn7C4CyocmlSMUPfkY9ORgab346vTHu5kX35PgW5XR51VD2nO5iJCFbyFcsmmRWyCJcZzwMNARouc2V4V8A==",
+      "requires": {
+        "@sentry/core": "7.51.2",
+        "@sentry/types": "7.51.2",
+        "@sentry/utils": "7.51.2",
+        "tslib": "^1.9.3"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "1.14.1",
+          "resolved": "https://repository.engineering.redhat.com/nexus/repository/registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+        }
+      }
+    },
+    "@sentry/core": {
+      "version": "7.51.2",
+      "resolved": "https://repository.engineering.redhat.com/nexus/repository/registry.npmjs.org/@sentry/core/-/core-7.51.2.tgz",
+      "integrity": "sha512-p8ZiSBxpKe+rkXDMEcgmdoyIHM/1bhpINLZUFPiFH8vzomEr7sgnwRhyrU8y/ADnkPeNg/2YF3QpDpk0OgZJUA==",
+      "requires": {
+        "@sentry/types": "7.51.2",
+        "@sentry/utils": "7.51.2",
+        "tslib": "^1.9.3"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "1.14.1",
+          "resolved": "https://repository.engineering.redhat.com/nexus/repository/registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+        }
+      }
+    },
+    "@sentry/node": {
+      "version": "7.51.2",
+      "resolved": "https://repository.engineering.redhat.com/nexus/repository/registry.npmjs.org/@sentry/node/-/node-7.51.2.tgz",
+      "integrity": "sha512-qtZ2xNVR0ZW+OZWb0Xw0Cdh2QJXOJkXjK84CGC2P4Y6jWrt+GVvwMANPItLT6mAh+ITszTJ5Gk5HHFRpYme5EA==",
+      "requires": {
+        "@sentry-internal/tracing": "7.51.2",
+        "@sentry/core": "7.51.2",
+        "@sentry/types": "7.51.2",
+        "@sentry/utils": "7.51.2",
+        "cookie": "^0.4.1",
+        "https-proxy-agent": "^5.0.0",
+        "lru_map": "^0.3.3",
+        "tslib": "^1.9.3"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "1.14.1",
+          "resolved": "https://repository.engineering.redhat.com/nexus/repository/registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+        }
+      }
+    },
+    "@sentry/types": {
+      "version": "7.51.2",
+      "resolved": "https://repository.engineering.redhat.com/nexus/repository/registry.npmjs.org/@sentry/types/-/types-7.51.2.tgz",
+      "integrity": "sha512-/hLnZVrcK7G5BQoD/60u9Qak8c9AvwV8za8TtYPJDUeW59GrqnqOkFji7RVhI7oH1OX4iBxV+9pAKzfYE6A6SA=="
+    },
+    "@sentry/utils": {
+      "version": "7.51.2",
+      "resolved": "https://repository.engineering.redhat.com/nexus/repository/registry.npmjs.org/@sentry/utils/-/utils-7.51.2.tgz",
+      "integrity": "sha512-EcjBU7qG4IG+DpIPvdgIBcdIofROMawKoRUNKraeKzH/waEYH9DzCaqp/mzc5/rPBhpDB4BShX9xDDSeH+8c0A==",
+      "requires": {
+        "@sentry/types": "7.51.2",
+        "tslib": "^1.9.3"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "1.14.1",
+          "resolved": "https://repository.engineering.redhat.com/nexus/repository/registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+        }
+      }
+    },
     "@sinclair/typebox": {
       "version": "0.24.51",
       "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.24.51.tgz",
@@ -10363,6 +10567,14 @@
       "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.2.0.tgz",
       "integrity": "sha512-k+iyHEuPgSw6SbuDpGQM+06HQUa04DZ3o+F6CSzXMvvI5KMvnaEqXe+YVe555R9nn6GPt404fos4wcgpw12SDA==",
       "dev": true
+    },
+    "agent-base": {
+      "version": "6.0.2",
+      "resolved": "https://repository.engineering.redhat.com/nexus/repository/registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
+      "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
+      "requires": {
+        "debug": "4"
+      }
     },
     "ajv": {
       "version": "8.12.0",
@@ -11657,6 +11869,15 @@
         "toidentifier": "1.0.1"
       }
     },
+    "https-proxy-agent": {
+      "version": "5.0.1",
+      "resolved": "https://repository.engineering.redhat.com/nexus/repository/registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
+      "integrity": "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==",
+      "requires": {
+        "agent-base": "6",
+        "debug": "4"
+      }
+    },
     "human-signals": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-2.1.0.tgz",
@@ -12444,6 +12665,11 @@
       "resolved": "https://registry.npmjs.org/lodash.memoize/-/lodash.memoize-4.1.2.tgz",
       "integrity": "sha512-t7j+NzmgnQzTAYXcsHYLgimltOV1MXHtlOWf6GjL9Kj8GK5FInw5JotxvbOs+IvV1/Dzo04/fCGfLVs7aXb4Ag==",
       "dev": true
+    },
+    "lru_map": {
+      "version": "0.3.3",
+      "resolved": "https://repository.engineering.redhat.com/nexus/repository/registry.npmjs.org/lru_map/-/lru_map-0.3.3.tgz",
+      "integrity": "sha512-Pn9cox5CsMYngeDbmChANltQl+5pi6XmTrraMSzhPmMBbmgcxmqWry0U3PGapCU1yB4/LqCcom7qhHZiF/jGfQ=="
     },
     "lru-cache": {
       "version": "5.1.1",

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
   "license": "LGPL-3.0-or-later",
   "dependencies": {
     "@graphql-tools/delegate": "^9.0.35",
+    "@sentry/node": "^7.51.2",
     "ajv": "^8.12.0",
     "ajv-formats": "^2.1.1",
     "axios": "^1.4.0",

--- a/src/routes/debugInfo.ts
+++ b/src/routes/debugInfo.ts
@@ -26,4 +26,8 @@ export default (app: Express) => {
     var answ = printify(req);
     res.send(answ);
   });
+
+  app.get('/debug/sentry', (req, res) => {
+    throw new Error('Testing backend Sentry integration.');
+  });
 };


### PR DESCRIPTION
Integrate the dashboard backend with Sentry. It's only necessary to set the `SENTRY_DSN` environment variable to enable the integration. It's also advisable to set the `SENTRY_ENVIRONMENT` to the appropriate value when deploying.

Reference: OSCI-5106