### PR TITLE
Extend Sentry integration to pino

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,18 @@ SRV_DB_URL='mongodb://root:passwordrootmongodb@127.0.0.1' DEBUG="osci:*" npm run
 SRV_DB_DB_NAME="oscidashboard" SRV_DB_URL='mongodb://oscidashboardro_user:XXXXX@dbproxy01.dba-001.prod.iad2.dc.redhat.com:32701/oscidashboard?authSource=admin&tls=true&tlsInsecure=true&replicaSet=mongoshared7&directConnection=true' DEBUG="osci:*" npm run dev:server
 ```
 
+## Sentry integration
+
+CI Dashboard outputs all log messages to the console. In addition to this, it is able to report runtime as well as GraphQL directly to Sentry. To specify the [Sentry DSN](https://docs.sentry.io/product/sentry-basics/dsn-explainer/) and [environment identifier](https://docs.sentry.io/product/sentry-basics/environments/), use the `SENTRY_DSN` and `SENTRY_ENVIRONMENT` environment variables. You can specify these in your `env.sh` or `env-devel.sh` file, for example:
+
+```bash
+# ...
+export SENTRY_DSN=https://1cafe2cafe3cafe@example.sentry.io/9999999
+export SENTRY_ENVIRONMENT=production
+```
+
+If the DSN is not specified, messages are only logged to the console.
+
 ## Code style
 
 In this project we follow the  [Google TypeScript Style Guide](https://google.github.io/styleguide/tsguide.html).

--- a/README.md
+++ b/README.md
@@ -33,11 +33,11 @@ classDef outside stroke-dasharray: 4
 
 Install certificates
 
- ```bash
+```bash
 yum install https://hdn.corp.redhat.com/rhel8-csb/RPMS/noarch/redhat-internal-cert-install-0.1-28.el7.noarch.rpm
 ```
 
- Install globally npmrc and create config file
+Install globally npmrc and create config file
 
 ```bash
 npm install -g npmrc
@@ -51,28 +51,28 @@ npmrc osci
 
 To set up server process this steps:
 
- 1. Clone repo
+1.  Clone repo
 
- 2. Run `npm install`
+2.  Run `npm install`
 
- 3. Configure `env-devel.sh` file:
+3.  Configure `env-devel.sh` file:
 
 ```bash
-#!/bin/bash  
-# development  
-export SRV_KOJI_BREW_HOST="brewhub.engineering.redhat.com"  
-export SRV_DISTGIT_RH_BASE_URL="http://pkgs.devel.redhat.com"  
-export SRV_GREENWAVE_URL='https://greenwave.engineering.redhat.com'  
-export SRV_WAIVERDB_URL='https://waiverdb.engineering.redhat.com'
+#!/bin/bash
+# development
+export SRV_KOJI_BREW_HOST="brewhub.engineering.redhat.com"
+export SRV_DISTGIT_RH_BASE_URL="http://pkgs.devel.redhat.com"
+export SRV_GREENWAVE_URL="https://greenwave.engineering.redhat.com"
+export SRV_WAIVERDB_URL="https://waiverdb.engineering.redhat.com"
 ```
 
- 4. Setup container running MongoDB:
+4.  Setup container running MongoDB:
 
 ```bash
 podman run -p 27017:27017 -e MONGODB_USERNAME=user -e MONGODB_PASSWORD=password -e MONGODB_DATABASE=ci-messages -e MONGODB_ROOT_PASSWORD=passwordrootmongodb bitnami/mongodb:latest
 ```
 
- 5. Start the server:
+5.  Start the server:
 
 ```bash
 SRV_DB_URL='mongodb://root:passwordrootmongodb@127.0.0.1' DEBUG="osci:*" npm run dev:server
@@ -98,8 +98,8 @@ If the DSN is not specified, messages are only logged to the console.
 
 ## Code style
 
-In this project we follow the  [Google TypeScript Style Guide](https://google.github.io/styleguide/tsguide.html).
+In this project we follow the [Google TypeScript Style Guide](https://google.github.io/styleguide/tsguide.html).
 
 ## License
 
-This project is licensed under the LGPLv3 License or later - see the  [LICENSE](/COPYING)  file for details
+This project is licensed under the LGPLv3 License or later - see the [LICENSE](/COPYING) file for details

--- a/package-lock.json
+++ b/package-lock.json
@@ -41,6 +41,7 @@
         "pino": "^8.14.1",
         "pino-http": "^8.3.3",
         "pino-pretty": "^10.0.0",
+        "pino-sentry": "^0.14.0",
         "retry": "^0.13.1",
         "tmp": "^0.2.1",
         "xmlrpc": "^1.3.2",
@@ -3567,6 +3568,12 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/commander": {
+      "version": "2.20.3",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
+      "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
+      "license": "MIT"
+    },
     "node_modules/concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
@@ -3817,6 +3824,32 @@
       "dev": true,
       "engines": {
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/duplexify": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/duplexify/-/duplexify-4.1.2.tgz",
+      "integrity": "sha512-fz3OjcNCHmRP12MJoZMPglx8m4rrFP8rovnk4vT8Fs+aonZoCwGg10dSsQsfP/E62eZcPTMSMP6686fu9Qlqtw==",
+      "license": "MIT",
+      "dependencies": {
+        "end-of-stream": "^1.4.1",
+        "inherits": "^2.0.3",
+        "readable-stream": "^3.1.1",
+        "stream-shift": "^1.0.0"
+      }
+    },
+    "node_modules/duplexify/node_modules/readable-stream": {
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
+      "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
+      "license": "MIT",
+      "dependencies": {
+        "inherits": "^2.0.3",
+        "string_decoder": "^1.1.1",
+        "util-deprecate": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
       }
     },
     "node_modules/ee-first": {
@@ -6576,6 +6609,48 @@
         "atomic-sleep": "^1.0.0"
       }
     },
+    "node_modules/pino-sentry": {
+      "version": "0.14.0",
+      "resolved": "https://registry.npmjs.org/pino-sentry/-/pino-sentry-0.14.0.tgz",
+      "integrity": "sha512-UwX0zgJk2ToA1c1f6QpJ7OlWEwxMFt5apJgCYNhhBbuuJuPDmqEzDRMrWKcbF3HKFuupoaNWK6S3o4XXPmI9Rw==",
+      "license": "MIT",
+      "dependencies": {
+        "@sentry/node": "^6.2.5||^7.1.1",
+        "commander": "^2.20.0",
+        "pumpify": "^2.0.1",
+        "split2": "^3.1.1",
+        "through2": "^3.0.1"
+      },
+      "bin": {
+        "pino-sentry": "dist/cli.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/pino-sentry/node_modules/readable-stream": {
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
+      "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
+      "license": "MIT",
+      "dependencies": {
+        "inherits": "^2.0.3",
+        "string_decoder": "^1.1.1",
+        "util-deprecate": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/pino-sentry/node_modules/split2": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/split2/-/split2-3.2.2.tgz",
+      "integrity": "sha512-9NThjpgZnifTkJpzTZ7Eue85S49QwpNhZTq6GRJwObb6jnLFNGB7Qm73V5HewTROPyxD0C29xqmaI68bQtV+hg==",
+      "license": "ISC",
+      "dependencies": {
+        "readable-stream": "^3.0.0"
+      }
+    },
     "node_modules/pino-std-serializers": {
       "version": "6.1.0",
       "resolved": "https://registry.npmjs.org/pino-std-serializers/-/pino-std-serializers-6.1.0.tgz",
@@ -6755,6 +6830,17 @@
       "dependencies": {
         "end-of-stream": "^1.1.0",
         "once": "^1.3.1"
+      }
+    },
+    "node_modules/pumpify": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/pumpify/-/pumpify-2.0.1.tgz",
+      "integrity": "sha512-m7KOje7jZxrmutanlkS1daj1dS6z6BgslzOXmcSEpIlCxM3VJH7lG5QLeck/6hgF6F4crFf01UtQmNsJfweTAw==",
+      "license": "MIT",
+      "dependencies": {
+        "duplexify": "^4.1.1",
+        "inherits": "^2.0.3",
+        "pump": "^3.0.0"
       }
     },
     "node_modules/qs": {
@@ -7354,6 +7440,12 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/stream-shift": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/stream-shift/-/stream-shift-1.0.1.tgz",
+      "integrity": "sha512-AiisoFqQ0vbGcZgQPY1cdP2I76glaVA/RauYR4G4thNFgkTqr90yXTo4LYX60Jl+sIlPNHHdGSwo01AvbKUSVQ==",
+      "license": "MIT"
+    },
     "node_modules/string_decoder": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
@@ -7517,6 +7609,30 @@
       "integrity": "sha512-kaDqm1DET9pp3NXwR8382WHbnpXnRkN9xGN9dQt3B2+dmXiW8X1SOwmFOxAErEQ47ObhZ96J6yhZNXuyCOL7KA==",
       "dependencies": {
         "real-require": "^0.2.0"
+      }
+    },
+    "node_modules/through2": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/through2/-/through2-3.0.2.tgz",
+      "integrity": "sha512-enaDQ4MUyP2W6ZyT6EsMzqBPZaM/avg8iuo+l2d3QCs0J+6RaqkHV/2/lOwDTueBHeJ/2LG9lrLW3d5rWPucuQ==",
+      "license": "MIT",
+      "dependencies": {
+        "inherits": "^2.0.4",
+        "readable-stream": "2 || 3"
+      }
+    },
+    "node_modules/through2/node_modules/readable-stream": {
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
+      "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
+      "license": "MIT",
+      "dependencies": {
+        "inherits": "^2.0.3",
+        "string_decoder": "^1.1.1",
+        "util-deprecate": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
       }
     },
     "node_modules/tmp": {
@@ -11076,6 +11192,11 @@
         "delayed-stream": "~1.0.0"
       }
     },
+    "commander": {
+      "version": "2.20.3",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
+      "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ=="
+    },
     "concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
@@ -11260,6 +11381,29 @@
       "resolved": "https://registry.npmjs.org/diff-sequences/-/diff-sequences-29.3.1.tgz",
       "integrity": "sha512-hlM3QR272NXCi4pq+N4Kok4kOp6EsgOM3ZSpJI7Da3UAs+Ttsi8MRmB6trM/lhyzUxGfOgnpkHtgqm5Q/CTcfQ==",
       "dev": true
+    },
+    "duplexify": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/duplexify/-/duplexify-4.1.2.tgz",
+      "integrity": "sha512-fz3OjcNCHmRP12MJoZMPglx8m4rrFP8rovnk4vT8Fs+aonZoCwGg10dSsQsfP/E62eZcPTMSMP6686fu9Qlqtw==",
+      "requires": {
+        "end-of-stream": "^1.4.1",
+        "inherits": "^2.0.3",
+        "readable-stream": "^3.1.1",
+        "stream-shift": "^1.0.0"
+      },
+      "dependencies": {
+        "readable-stream": {
+          "version": "3.6.2",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
+          "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
+          "requires": {
+            "inherits": "^2.0.3",
+            "string_decoder": "^1.1.1",
+            "util-deprecate": "^1.0.1"
+          }
+        }
+      }
     },
     "ee-first": {
       "version": "1.1.1",
@@ -13360,6 +13504,38 @@
         }
       }
     },
+    "pino-sentry": {
+      "version": "0.14.0",
+      "resolved": "https://registry.npmjs.org/pino-sentry/-/pino-sentry-0.14.0.tgz",
+      "integrity": "sha512-UwX0zgJk2ToA1c1f6QpJ7OlWEwxMFt5apJgCYNhhBbuuJuPDmqEzDRMrWKcbF3HKFuupoaNWK6S3o4XXPmI9Rw==",
+      "requires": {
+        "@sentry/node": "^6.2.5||^7.1.1",
+        "commander": "^2.20.0",
+        "pumpify": "^2.0.1",
+        "split2": "^3.1.1",
+        "through2": "^3.0.1"
+      },
+      "dependencies": {
+        "readable-stream": {
+          "version": "3.6.2",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
+          "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
+          "requires": {
+            "inherits": "^2.0.3",
+            "string_decoder": "^1.1.1",
+            "util-deprecate": "^1.0.1"
+          }
+        },
+        "split2": {
+          "version": "3.2.2",
+          "resolved": "https://registry.npmjs.org/split2/-/split2-3.2.2.tgz",
+          "integrity": "sha512-9NThjpgZnifTkJpzTZ7Eue85S49QwpNhZTq6GRJwObb6jnLFNGB7Qm73V5HewTROPyxD0C29xqmaI68bQtV+hg==",
+          "requires": {
+            "readable-stream": "^3.0.0"
+          }
+        }
+      }
+    },
     "pino-std-serializers": {
       "version": "6.1.0",
       "resolved": "https://registry.npmjs.org/pino-std-serializers/-/pino-std-serializers-6.1.0.tgz",
@@ -13491,6 +13667,16 @@
       "requires": {
         "end-of-stream": "^1.1.0",
         "once": "^1.3.1"
+      }
+    },
+    "pumpify": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/pumpify/-/pumpify-2.0.1.tgz",
+      "integrity": "sha512-m7KOje7jZxrmutanlkS1daj1dS6z6BgslzOXmcSEpIlCxM3VJH7lG5QLeck/6hgF6F4crFf01UtQmNsJfweTAw==",
+      "requires": {
+        "duplexify": "^4.1.1",
+        "inherits": "^2.0.3",
+        "pump": "^3.0.0"
       }
     },
     "qs": {
@@ -13921,6 +14107,11 @@
       "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.1.tgz",
       "integrity": "sha512-RwNA9Z/7PrK06rYLIzFMlaF+l73iwpzsqRIFgbMLbTcLD6cOao82TaWefPXQvB2fOC4AjuYSEndS7N/mTCbkdQ=="
     },
+    "stream-shift": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/stream-shift/-/stream-shift-1.0.1.tgz",
+      "integrity": "sha512-AiisoFqQ0vbGcZgQPY1cdP2I76glaVA/RauYR4G4thNFgkTqr90yXTo4LYX60Jl+sIlPNHHdGSwo01AvbKUSVQ=="
+    },
     "string_decoder": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
@@ -14052,6 +14243,27 @@
       "integrity": "sha512-kaDqm1DET9pp3NXwR8382WHbnpXnRkN9xGN9dQt3B2+dmXiW8X1SOwmFOxAErEQ47ObhZ96J6yhZNXuyCOL7KA==",
       "requires": {
         "real-require": "^0.2.0"
+      }
+    },
+    "through2": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/through2/-/through2-3.0.2.tgz",
+      "integrity": "sha512-enaDQ4MUyP2W6ZyT6EsMzqBPZaM/avg8iuo+l2d3QCs0J+6RaqkHV/2/lOwDTueBHeJ/2LG9lrLW3d5rWPucuQ==",
+      "requires": {
+        "inherits": "^2.0.4",
+        "readable-stream": "2 || 3"
+      },
+      "dependencies": {
+        "readable-stream": {
+          "version": "3.6.2",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
+          "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
+          "requires": {
+            "inherits": "^2.0.3",
+            "string_decoder": "^1.1.1",
+            "util-deprecate": "^1.0.1"
+          }
+        }
       }
     },
     "tmp": {

--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
     "pino": "^8.14.1",
     "pino-http": "^8.3.3",
     "pino-pretty": "^10.0.0",
+    "pino-sentry": "^0.14.0",
     "retry": "^0.13.1",
     "tmp": "^0.2.1",
     "xmlrpc": "^1.3.2",

--- a/src/logger.js
+++ b/src/logger.js
@@ -1,31 +1,51 @@
 /*
  * This file is part of ciboard-server
-
+ *
  * Copyright (c) 2021 Andrei Stepanov <astepano@redhat.com>
- * 
+ *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public
  * License as published by the Free Software Foundation; either
  * version 3 of the License, or (at your option) any later version.
- * 
+ *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
  * Lesser General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU Lesser General Public License
  * along with this program; if not, write to the Free Software Foundation,
  * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  */
 
-const pino = require('pino');
 const util = require('util');
+
 const debug = require('debug');
+const pino = require('pino');
+const pinoPretty = require('pino-pretty');
+const pinoSentry = require('pino-sentry');
+
+/*
+ * Pretty-print log messages to the console-using pino-pretty. In addition
+ * to that, forward warnings (and higher-level messages) to Sentry, if enabled.
+ */
+const pinoStreams = pino.multistream([
+  {
+    stream: pinoPretty(),
+    level: process.env.LOG_LEVEL || 'debug',
+  },
+  /*
+   * Note: The Sentry DSN is read automatically from the environment variable
+   * SENTRY_DSN, as specified in the DeploymentConfig. If no DSN is specified,
+   * this stream does nothing.
+   */
+  { stream: pinoSentry.createWriteStream(), level: 'warn' },
+]);
 
 /**
  * off, fatal, error, warn, info, debug, trace
  */
-const logger = pino({ level: process.env.LOG_LEVEL || 'debug' });
+export const logger = pino.pino({}, pinoStreams);
 
 /**
  * https://wildwolf.name/easy-way-to-make-pino-and-debug-work-together/
@@ -33,5 +53,3 @@ const logger = pino({ level: process.env.LOG_LEVEL || 'debug' });
 debug.log = function (s, ...args) {
   logger.debug(util.format(s, ...args));
 };
-
-module.exports = logger;

--- a/src/routes/graphql.ts
+++ b/src/routes/graphql.ts
@@ -1,37 +1,48 @@
 /*
  * This file is part of ciboard-server
-
+ *
  * Copyright (c) 2021 Andrei Stepanov <astepano@redhat.com>
- * 
+ *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public
  * License as published by the Free Software Foundation; either
  * version 3 of the License, or (at your option) any later version.
- * 
+ *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
  * Lesser General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU Lesser General Public License
  * along with this program; if not, write to the Free Software Foundation,
  * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  */
 
-import { graphqlHTTP } from 'express-graphql';
-import schema from '../schema/schema';
 import { Express } from 'express';
+import { graphqlHTTP } from 'express-graphql';
+import * as graphql from 'graphql';
+
+import { logger } from '../logger';
+import schema from '../schema/schema';
 
 export default (app: Express) => {
   app.use(
     '/graphql',
     graphqlHTTP({
+      customFormatErrorFn(error) {
+        // Report the error to console as a warning.
+        const errorString = graphql.printError(error);
+        logger.warn(`GraphQL error: ${errorString}`);
+
+        // Pass through the error object itself unchanged.
+        return error;
+      },
       /**
        * graphiql -- only available in delevelopment environment
        * Allows run queries agains development server
        */
       graphiql: true,
       schema,
-    })
+    }),
   );
 };

--- a/src/server.ts
+++ b/src/server.ts
@@ -32,7 +32,8 @@ import cookieSession from 'cookie-session';
 import expressPino from 'pino-http';
 
 import { getcfg } from './cfg';
-import logger from './pino_logger';
+import { logger } from './logger';
+
 const log = debug('osci:server');
 const cfg = getcfg();
 

--- a/src/server.ts
+++ b/src/server.ts
@@ -51,6 +51,9 @@ const app = express();
  * Enable Sentry integration. For more details on the Express.js integration
  * and set up, see the documentation:
  * https://docs.sentry.io/platforms/node/guides/express/
+ * Note: The Sentry DSN is read automatically from the environment variable
+ * SENTRY_DSN, as specified in the DeploymentConfig. If no DSN is specified,
+ * this integration does nothing.
  */
 Sentry.init({
   integrations: [
@@ -61,8 +64,6 @@ Sentry.init({
     // Automatically instrument Node.js libraries and frameworks.
     ...Sentry.autoDiscoverNodePerformanceMonitoringIntegrations(),
   ],
-  // Capture 1/4 of transactions for performance monitoring.
-  tracesSampleRate: 0.25,
 });
 
 /*


### PR DESCRIPTION
This PR improves Sentry integration to include all warnings and errors that go through pino, which includes the vast majority of messages. This should catch pretty much all errors that might appear in the app.

In addition to that, intercept GraphQL errors and report them to Sentry as well.

Follow-up to #110.