### PR TITLE
Use Git commit as Sentry release

### DIFF
--- a/.github/workflows/build-image.yaml
+++ b/.github/workflows/build-image.yaml
@@ -37,12 +37,16 @@ jobs:
 
     - name: Set outputs
       id: vars
-      run: echo "sha_short=$(git rev-parse --short HEAD)" >> $GITHUB_OUTPUT
+      run: |
+        echo "sha_long=$(git rev-parse HEAD)" >> $GITHUB_OUTPUT
+        echo "sha_short=$(git rev-parse --short HEAD)" >> $GITHUB_OUTPUT
 
     - name: Build Image
       id: build-image
       uses: redhat-actions/buildah-build@v2
       with:
+        build-args: |
+          GITCOMMIT=${{ steps.vars.outputs.sha_long }}
         tags: |
             ${{ env.IMAGE_REGISTRY_GITHUB }}:${{ steps.vars.outputs.sha_short }}
             ${{ ( github.ref == 'refs/heads/main' && format('{0}:latest', env.IMAGE_REGISTRY_GITHUB) ) || '' }}

--- a/src/server.ts
+++ b/src/server.ts
@@ -65,6 +65,7 @@ Sentry.init({
     // Automatically instrument Node.js libraries and frameworks.
     ...Sentry.autoDiscoverNodePerformanceMonitoringIntegrations(),
   ],
+  release: process.env.CIBOARD_SERVER_GIT_COMMIT || 'custom-build',
 });
 
 /*


### PR DESCRIPTION
Pass the long Git commit of the source branch as the app release to Sentry. This allows verifying that bugfixes work correctly in new versions of CI Dashboard.