### PR TITLE
Fix 404 error when retrieving commit info for modules

### DIFF
--- a/src/schema/mbs_types.ts
+++ b/src/schema/mbs_types.ts
@@ -128,7 +128,8 @@ const commitResolver: graphql.GraphQLFieldResolver<any, {}, any> = async (
   const { scmurl } = parentValue;
   const { instance } = args;
   const nameWithCommit = _.last(_.split(scmurl, 'modules/'));
-  const [repoName, sha1] = _.split(nameWithCommit, '?#');
+  const [repoNameDotGit, sha1] = _.split(nameWithCommit, '?#');
+  const repoName = _.replace(repoNameDotGit, /.git$/, '');
   if (!repoName || !sha1) {
     throw new Error(
       `Could not parse repo name and commit from URL '${scmurl}'`,


### PR DESCRIPTION
The code failed to strip the `.git` suffix from the repository URL, thus causing an HTTP 404 error when trying to retrieve an object such as https://pkgs.example/cgit/modules/go-toolset.git/objects/bd/f7...

Reference: ARR-001-CI-DASHBOARD-1X
Reference: OSCI-5203