### PR TITLE
Fix search order of test results.

### DIFF
--- a/src/schema/artifacts.ts
+++ b/src/schema/artifacts.ts
@@ -158,31 +158,6 @@ export const makeRequestParamsArtifacts = (
                       ${_.trimEnd(rangeFilterParam, ', \n')}
                     ]
                   }
-                },
-                "score_mode": "max",
-                "inner_hits": {
-                  "_source": "false",
-                  "sort": [
-                    {
-                      "_score": {
-                        "order": "desc"
-                      }
-                    },
-                    {
-                      "taskId.number": {
-                        "order": "desc",
-                        "unmapped_type" : "long"
-                      },
-                      "mbsId.number": {
-                        "order": "desc",
-                        "unmapped_type" : "long"
-                      },
-                      "buildId.number": {
-                        "order": "desc",
-                        "unmapped_type" : "long"
-                      }
-                    }
-                  ]
                 }
               }
             },
@@ -217,11 +192,6 @@ export const makeRequestParamsArtifacts = (
         }
       },
       "sort": [
-        {
-          "_score": {
-            "order": "desc"
-          }
-        },
         {
           "taskId.number": {
             "order": "desc",


### PR DESCRIPTION
The hits were being ordered twice, which is unnecessary, so the inner sort is removed.

Ordering by score causes issues because multiple hits can end up with the same score, and then the order doesn't match the Id order in the table. Removing the score makes the sort correct.